### PR TITLE
Remove left-pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,3 @@ Additional lines of context can be shown by including the `--context [num]` opti
 #### Column marker
 
 It is possible to prevent the column marker to be shown with the `--no-marker` option.
-
-## Disclaimer
-
-This module uses [`left-pad`](https://www.npmjs.com/package/left-pad). Use at your own risk.

--- a/lib/lineSlicer.js
+++ b/lib/lineSlicer.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const leftPad = require('left-pad');
-
 function slice (text, line, column, opts) {
   const delimiter = opts.delimiter || '\n';
   const before = opts.before || opts.context || 0;
@@ -10,7 +8,7 @@ function slice (text, line, column, opts) {
   const begin = Math.max(0, line - before - 1);
   const end = Math.min(line + after - 1, lines.length - 1);
   const slice = lines.slice(begin, end + 1);
-  if (opts.marker) slice.splice(line - begin, 0, leftPad('^', column + 1));
+  if (opts.marker) slice.splice(line - begin, 0, '^'.padStart(column + 1));
   return slice.join(delimiter);
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "license": "WTFPL",
   "author": "Gabriel Montes",
   "contributors": [
-    "Mauro Titimoli"
+    "Mauro Titimoli",
+    "Sawyer Hollenshead"
   ],
   "bin": {
     "source-map": "bin/source-map.js"
@@ -26,8 +27,10 @@
   "scripts": {},
   "dependencies": {
     "commander": "^2.9.0",
-    "left-pad": "^1.0.2",
     "path-loader": "^1.0.1",
     "source-map": "^0.5.3"
+  },
+  "engines": {
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
`left-pad` is deprecated and its NPM page suggests using `String.prototype.padStart()` instead.